### PR TITLE
Fix PIA jason request to work with split tunnel

### DIFF
--- a/transmission-pia-port-forwarding.sh
+++ b/transmission-pia-port-forwarding.sh
@@ -46,7 +46,7 @@ PIA_PF_API_URL=http://209.222.18.222:2000/?client_id
 
 echo 'Requesting open port assignment from PIA ...'
 
-PIA_API_JSON_RESPONSE=`curl "${PIA_PF_API_URL}=${LM_ID}" -m ${CURL_TIMEOUT} 2> /dev/null`
+PIA_API_JSON_RESPONSE=$(curl -m $CURL_TIMEOUT --silent --interface $VPNINTERFACE "${PIA_PF_API_URL}=${LM_ID}")
 
 if [ "${PIA_API_JSON_RESPONSE}" == "" ]; then
   echo "Hmmm: did not get a port from PIA. Maybe ..."


### PR DESCRIPTION
The script was not working with split tunnel. It failed in PIA fort forward API JASON request. You need to specify the VPN Interface since the default Interface is no longer the VPN tunnel.